### PR TITLE
unescape copy source value before using

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -553,6 +553,11 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 		srcBucket := parts[0]
 		srcKey := parts[1]
 
+		srcKey, err = url.QueryUnescape(srcKey)
+		if err != nil {
+			return err
+		}
+
 		src, err := g.storage.GetObject(srcBucket, srcKey, nil)
 		if err != nil {
 			return err

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -625,6 +625,11 @@ func (g *GoFakeS3) copyObject(bucket, object string, meta map[string]string, w h
 	srcBucket := parts[0]
 	srcKey := strings.SplitN(parts[1], "?", 2)[0]
 
+	srcKey, err = url.QueryUnescape(srcKey)
+	if err != nil {
+		return err
+	}
+
 	srcObj, err := g.storage.GetObject(srcBucket, srcKey, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR is a replication of PR https://github.com/johannesboyne/gofakes3/pull/53.
Since s5cmd tests are flaky with the upstream gofakes3 we decided to use this fork.

With this version of gofakes3, s5cmd tests are passing. https://github.com/peak/s5cmd/pull/286