### PR TITLE
save time of objects when uploading to s3

### DIFF
--- a/backend/s3bolt/backend.go
+++ b/backend/s3bolt/backend.go
@@ -159,12 +159,16 @@ func (db *Backend) ListBucket(name string, prefix *gofakes3.Prefix, page gofakes
 				objects.AddPrefix(match.MatchedPart)
 
 			} else {
-				hash := md5.Sum(v)
+				var b boltObject
+				err := bson.Unmarshal(v, &b)
+				if err != nil {
+					return fmt.Errorf("gofakes3: could not unmarshal object %q: %v", string(k[:]), err)
+				}
 				item := &gofakes3.Content{
-					Key:          string(k),
+					Key:          string(k[:]),
 					LastModified: mod,
-					ETag:         `"` + hex.EncodeToString(hash[:]) + `"`,
-					Size:         int64(len(v)),
+					ETag:         `"` + hex.EncodeToString(b.Hash[:]) + `"`,
+					Size:         b.Size,
 				}
 				objects.Add(item)
 			}

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -279,6 +279,30 @@ func TestCopyObject(t *testing.T) {
 	}
 }
 
+func TestListBucketObjectSize(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	_, err := svc.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(defaultBucket),
+		Key:    aws.String("object"),
+		Body:   bytes.NewReader([]byte("hello")), // size 5
+	})
+	ts.OK(err)
+
+	listInput := s3.ListObjectsV2Input{
+		Bucket: aws.String(defaultBucket),
+	}
+
+	output, err := svc.ListObjectsV2(&listInput) // there should be only 1 object
+	ts.OK(err)
+
+	if *output.Contents[0].Size != int64(5) {
+		ts.Fatalf("Size wanted 5 got :%v\n", *output.Contents[0].Size)
+	}
+}
+
 func TestDeleteBucket(t *testing.T) {
 	t.Run("delete-empty", func(t *testing.T) {
 		ts := newTestServer(t, withoutInitialBuckets())


### PR DESCRIPTION
We need object modification time testing `sync`. `gofakes3` does not give the time in a correct way.

1. So I modified the code to save the upload time when `PutObject` is called.
2. We have object time when `ListBucket` is called.

I also added a small test case for my [previous PR](https://github.com/igungor/gofakes3/pull/3)