### PR TITLE
fix unaligned 64-bit atomic operation error

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -23,6 +23,8 @@ import (
 //
 // Logic is delegated to other components, like Backend or uploader.
 type GoFakeS3 struct {
+	requestID uint64
+
 	storage   Backend
 	versioned VersionedBackend
 
@@ -33,7 +35,6 @@ type GoFakeS3 struct {
 	failOnUnimplementedPage bool
 	hostBucket              bool
 	uploader                *uploader
-	requestID               uint64
 	log                     Logger
 }
 


### PR DESCRIPTION
Fixes unaligned 64-bit atomic operation error in 32-bit architectures.

Brings same fix from https://github.com/johannesboyne/gofakes3/pull/48 to  fork
Updates https://github.com/peak/s5cmd/issues/446