### PR TITLE
feat: support for `metadata-directive`

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -1039,10 +1039,13 @@ func metadataHeaders(headers map[string][]string, at time.Time, sizeLimit int) (
 		if strings.HasPrefix(hk, "X-Amz-") ||
 			hk == "Content-Type" ||
 			hk == "Content-Disposition" ||
-			hk == "Content-Encoding" {
+			hk == "Content-Encoding" ||
+			hk == "Expires" ||
+			hk == "Cache-Control" {
 			meta[hk] = hv[0]
 		}
 	}
+
 	meta["Last-Modified"] = formatHeaderTime(at)
 
 	if sizeLimit > 0 && metadataSize(meta) > sizeLimit {

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -578,8 +578,20 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 		if err != nil {
 			return err
 		}
-		size = src.Size
 
+		if src == nil {
+			g.log.Print(LogErr, "unexpected nil object for key", bucket, object)
+			return ErrInternal
+		}
+
+		if meta["X-Amz-Metadata-Directive"] == "COPY" {
+			meta = src.Metadata
+		}
+
+		// this is not actually a part of the metadata
+		delete(src.Metadata, "X-Amz-Metadata-Directive")
+
+		size = src.Size
 		body = src.Contents
 
 	} else {

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -579,11 +579,6 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 			return err
 		}
 
-		if src == nil {
-			g.log.Print(LogErr, "unexpected nil object for key", bucket, object)
-			return ErrInternal
-		}
-
 		if meta["X-Amz-Metadata-Directive"] == "COPY" {
 			meta = src.Metadata
 		}

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -306,22 +306,37 @@ func TestCopyObject(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()
 	svc := ts.s3Client()
+	ts.backendPutString(defaultBucket, "src-key", nil, "content")
+	l, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket: aws.String(defaultBucket),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, v := range l.Contents {
+		fmt.Println(*v.Key)
+	}
 
 	srcMeta := map[string]string{
-		"Content-Type":   "text/plain",
-		"X-Amz-Meta-One": "src",
-		"X-Amz-Meta-Two": "src",
+		"Content-Type":     "text/plain",
+		"X-Amz-Meta-One":   "src",
+		"X-Amz-Meta-Two":   "src",
+		"X-Amz-Meta-Three": "src",
 	}
+
 	ts.backendPutString(defaultBucket, "src-key", srcMeta, "content")
 
 	out, err := svc.CopyObject(&s3.CopyObjectInput{
 		Bucket:     aws.String(defaultBucket),
 		Key:        aws.String("dst-key"),
-		CopySource: aws.String("/" + defaultBucket + "/src-key"),
+		CopySource: aws.String(defaultBucket + "/src-key"),
 		Metadata: map[string]*string{
 			"Two":   aws.String("dst"),
 			"Three": aws.String("dst"),
 		},
+		MetadataDirective: aws.String("COPY"),
 	})
 	ts.OK(err)
 
@@ -342,6 +357,54 @@ func TestCopyObject(t *testing.T) {
 
 	if v := obj.Metadata["X-Amz-Meta-One"]; v != "src" {
 		t.Fatalf("bad Content-Type: %q", v)
+	}
+
+	if v := obj.Metadata["X-Amz-Meta-Two"]; v != "src" {
+		t.Fatalf("bad Content-Encoding: %q", v)
+	}
+
+	if v := obj.Metadata["X-Amz-Meta-Three"]; v != "src" {
+		t.Fatalf("bad Content-Encoding: %q", v)
+	}
+}
+
+func TestCopyObjectWithReplaceDirective(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	svc := ts.s3Client()
+
+	srcMeta := map[string]string{
+		"Content-Type":   "text/plain",
+		"X-Amz-Meta-One": "src",
+		"X-Amz-Meta-Two": "src",
+	}
+	ts.backendPutString(defaultBucket, "src-key", srcMeta, "content")
+
+	out, err := svc.CopyObject(&s3.CopyObjectInput{
+		Bucket:     aws.String(defaultBucket),
+		Key:        aws.String("dst-key"),
+		CopySource: aws.String(defaultBucket + "/src-key"),
+		Metadata: map[string]*string{
+			"Two":   aws.String("dst"),
+			"Three": aws.String("dst"),
+		},
+		MetadataDirective: aws.String("REPLACE"),
+	})
+	ts.OK(err)
+
+	if *out.CopyObjectResult.ETag != `"9a0364b9e99bb480dd25e1f0284c8555"` { // md5("content")
+		ts.Fatal("bad etag", *out.CopyObjectResult.ETag)
+	}
+
+	obj, err := ts.backend.GetObject(defaultBucket, "dst-key", nil)
+	ts.OK(err)
+
+	defer obj.Contents.Close()
+	data, err := ioutil.ReadAll(obj.Contents)
+	ts.OK(err)
+
+	if string(data) != "content" {
+		t.Fatal("object copying failed")
 	}
 
 	if v := obj.Metadata["X-Amz-Meta-Two"]; v != "dst" {

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -306,18 +306,6 @@ func TestCopyObject(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()
 	svc := ts.s3Client()
-	ts.backendPutString(defaultBucket, "src-key", nil, "content")
-	l, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{
-		Bucket: aws.String(defaultBucket),
-	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, v := range l.Contents {
-		fmt.Println(*v.Key)
-	}
 
 	srcMeta := map[string]string{
 		"Content-Type":     "text/plain",


### PR DESCRIPTION
This feature allows to specify whether to keep the existing metadata of the object or replace with a new one when copying from `s3` to `s3`. Will be used in the tests of the [PR](https://github.com/peak/s5cmd/pull/668).