### PR TITLE
fix: fixed storageClass default value logic

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -618,7 +618,7 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 		return err
 	}
 
-	if r.Header.Get("x-amz-storage-class") != "" {
+	if r.Header.Get("x-amz-storage-class") == "" {
 		r.Header.Set("x-amz-storage-class", "STANDARD")
 	}
 


### PR DESCRIPTION
In the `createObject` function, if the incoming request's `x-amz-storage-class` header was empty, it was being set to `STANDARD`. The current behavior is the opposite: if the header is present, it gets set to `STANDARD`. This pull request fixes that issue.